### PR TITLE
Fix TypeError in Sequence finalizer (missing h5f arg)

### DIFF
--- a/src/loader/dsec/loader.py
+++ b/src/loader/dsec/loader.py
@@ -79,7 +79,7 @@ class Sequence(Dataset):
         else:
             raise ValueError(f"Invalid phase: {self.phase}")
         
-        self._finalizer = weakref.finalize(self, self._close_h5_file)
+        self._finalizer = weakref.finalize(self, self._close_h5_file, self.event_slicer.h5f)
 
     def _initialize_event_data(self, seq_path: Path):
         """Load event data and rectify map from h5 files."""


### PR DESCRIPTION
## Summary

`src/loader/dsec/loader.py` registers a `weakref.finalize` callback without passing the argument the callback requires, which produces a noisy traceback every time a `Sequence` is garbage-collected:

```
Exception ignored in: <finalize object ...>
Traceback (most recent call last):
  File ".../weakref.py", line 591, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
TypeError: Sequence._close_h5_file() missing 1 required positional argument: 'h5f'
```

## Cause

```python
@staticmethod
def _close_h5_file(h5f):
    h5f.close()

# ...
self._finalizer = weakref.finalize(self, self._close_h5_file)  # no h5f passed
```

The HDF5 file handle lives on `self.event_slicer.h5f`, but the finalizer was never given it.

## Fix

Pass the handle explicitly:

```python
self._finalizer = weakref.finalize(self, self._close_h5_file, self.event_slicer.h5f)
```

Observed during `scripts/dsec_inference.py` runs on the DSEC test set; the traceback no longer appears after the fix, and the h5 file is properly closed on GC.